### PR TITLE
feat: tri des colonnes dans le tableau des notes de frais

### DIFF
--- a/app/components/note-de-frais/ReportTable.tsx
+++ b/app/components/note-de-frais/ReportTable.tsx
@@ -2,6 +2,9 @@ import { ExpenseReport } from "@/app/interfaces/noteDeFraisInterface";
 import ReportRow from './ReportRow';
 import React from "react";
 import useStore from "@/app/store/useStore";
+import { useSortableTable } from '@/app/hooks/useSortableTable';
+import SortableHeader from './SortableHeader';
+import { calculateTotals } from '@/app/utils/helper';
 
 interface ReportTableProps {
     reports: ExpenseReport[];
@@ -17,7 +20,25 @@ const ReportTable: React.FC<ReportTableProps> = ({ reports, isLoading }) => {
     const requesterFilter = useStore((state) => state.requesterFilter).toLowerCase();
     const typeFilter = useStore((state) => state.typeFilter);
 
-    const reportFiltered = reports.filter((report) => {
+    // Vérifier que reports est bien un tableau
+    if (!Array.isArray(reports)) {
+        console.error('Reports is not an array:', reports);
+        return (
+            <div className="inline-block min-w-full overflow-hidden rounded-lg shadow">
+                <div className="p-4 text-center text-red-600">
+                    Erreur lors du chargement des données
+                </div>
+            </div>
+        );
+    }
+
+    // Ajouter le montant calculé à chaque rapport pour le tri
+    const reportsWithAmount = reports.map(report => ({
+        ...report,
+        calculatedAmount: calculateTotals(report.details).totalRemboursable
+    }));
+
+    const reportFiltered = reportsWithAmount.filter((report) => {
         const matchesStatus = status === 'Toutes' || report.status === status;
         const matchesSearchTerm = report.event.titre.toLowerCase().includes(searchTerm);
         const matchesDate = !dateFilter || new Date(report.event.tsp).toLocaleDateString() === new Date(dateFilter).toLocaleDateString();
@@ -30,39 +51,84 @@ const ReportTable: React.FC<ReportTableProps> = ({ reports, isLoading }) => {
         return matchesStatus && matchesSearchTerm && matchesDate && matchesRequester && matchesType;
     });
 
+    // Utiliser le hook de tri
+    const { sortedData, sortConfig, handleSort } = useSortableTable(reportFiltered);
+
     const startIndex = (currentPage - 1) * itemsPerPage;
     const endIndex = startIndex + itemsPerPage;
-    const paginatedReports = reportFiltered.slice(startIndex, endIndex);
+    const paginatedReports = sortedData.slice(startIndex, endIndex);
 
     return (
         <div className="inline-block min-w-full overflow-hidden rounded-lg shadow">
             <table className="min-w-full leading-normal">
                 <thead>
                     <tr>
-                        <th className="w-8 px-1 py-2 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
-                            Com.
-                        </th>
-                        <th className="w-1/3 px-2 py-2 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
-                            Note de frais
-                        </th>
-                        <th className="w-1/6 px-2 py-2 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
-                            Demandeur
-                        </th>
-                        <th className="w-20 px-2 py-2 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
-                            Date sortie
-                        </th>
-                        <th className="w-20 px-2 py-2 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
-                            Soumission
-                        </th>
-                        <th className="w-20 px-2 py-2 text-xs font-semibold tracking-wider text-left text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
-                            Montant
-                        </th>
-                        <th className="w-24 px-2 py-2 text-xs font-semibold tracking-wider text-center text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
-                            Type
-                        </th>
-                        <th className="w-20 px-2 py-2 text-xs font-semibold tracking-wider text-center text-gray-600 uppercase bg-gray-100 border-b-2 border-gray-200">
-                            Statut
-                        </th>
+                        <SortableHeader
+                            label="Com."
+                            sortKey="event.commission.id"
+                            currentSortKey={sortConfig.key}
+                            sortDirection={sortConfig.direction}
+                            onSort={handleSort}
+                            className="w-8 px-1 py-2"
+                        />
+                        <SortableHeader
+                            label="Note de frais"
+                            sortKey="event.titre"
+                            currentSortKey={sortConfig.key}
+                            sortDirection={sortConfig.direction}
+                            onSort={handleSort}
+                            className="w-1/3 px-2 py-2"
+                        />
+                        <SortableHeader
+                            label="Demandeur"
+                            sortKey="user.lastname"
+                            currentSortKey={sortConfig.key}
+                            sortDirection={sortConfig.direction}
+                            onSort={handleSort}
+                            className="w-1/6 px-2 py-2"
+                        />
+                        <SortableHeader
+                            label="Date sortie"
+                            sortKey="event.tsp"
+                            currentSortKey={sortConfig.key}
+                            sortDirection={sortConfig.direction}
+                            onSort={handleSort}
+                            className="w-20 px-2 py-2"
+                        />
+                        <SortableHeader
+                            label="Soumission"
+                            sortKey="createdAt"
+                            currentSortKey={sortConfig.key}
+                            sortDirection={sortConfig.direction}
+                            onSort={handleSort}
+                            className="w-20 px-2 py-2"
+                        />
+                        <SortableHeader
+                            label="Montant"
+                            sortKey="calculatedAmount"
+                            currentSortKey={sortConfig.key}
+                            sortDirection={sortConfig.direction}
+                            onSort={handleSort}
+                            className="w-20 px-2 py-2"
+                        />
+                        <SortableHeader
+                            label="Type"
+                            sortKey="refundRequired"
+                            currentSortKey={sortConfig.key}
+                            sortDirection={sortConfig.direction}
+                            onSort={handleSort}
+                            className="w-24 px-2 py-2"
+                            align="center"
+                        />
+                        <SortableHeader
+                            label="Statut"
+                            sortKey="status"
+                            currentSortKey={sortConfig.key}
+                            sortDirection={sortConfig.direction}
+                            onSort={handleSort}
+                            className="w-20 px-2 py-2"
+                            align="center"
+                        />
                     </tr>
                 </thead>
                 <tbody>

--- a/app/components/note-de-frais/SortableHeader.tsx
+++ b/app/components/note-de-frais/SortableHeader.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { FaSort, FaSortUp, FaSortDown } from 'react-icons/fa';
+import { SortDirection } from '@/app/hooks/useSortableTable';
+
+interface SortableHeaderProps {
+  label: string;
+  sortKey: string;
+  currentSortKey: string;
+  sortDirection: SortDirection;
+  onSort: (key: string) => void;
+  className?: string;
+  align?: 'left' | 'center' | 'right';
+}
+
+const SortableHeader: React.FC<SortableHeaderProps> = ({
+  label,
+  sortKey,
+  currentSortKey,
+  sortDirection,
+  onSort,
+  className = '',
+  align = 'left',
+}) => {
+  const isActive = currentSortKey === sortKey;
+  
+  const getSortIcon = () => {
+    if (!isActive || sortDirection === null) {
+      return <FaSort className="ml-1 opacity-30" />;
+    }
+    if (sortDirection === 'asc') {
+      return <FaSortUp className="ml-1 text-blue-600" />;
+    }
+    return <FaSortDown className="ml-1 text-blue-600" />;
+  };
+
+  const alignClass = align === 'center' ? 'justify-center' : align === 'right' ? 'justify-end' : 'justify-start';
+
+  return (
+    <th 
+      className={`${className} bg-gray-100 border-b-2 border-gray-200 cursor-pointer hover:bg-gray-200 transition-colors`}
+      onClick={() => onSort(sortKey)}
+    >
+      <div className={`flex items-center ${alignClass}`}>
+        <span className="text-xs font-semibold tracking-wider text-gray-600 uppercase">
+          {label}
+        </span>
+        {getSortIcon()}
+      </div>
+    </th>
+  );
+};
+
+export default SortableHeader;

--- a/app/hooks/useSortableTable.ts
+++ b/app/hooks/useSortableTable.ts
@@ -1,0 +1,66 @@
+import { useState, useMemo } from 'react';
+
+export type SortDirection = 'asc' | 'desc' | null;
+
+export interface SortConfig<T> {
+  key: keyof T | string;
+  direction: SortDirection;
+}
+
+export function useSortableTable<T>(
+  data: T[],
+  defaultSort?: SortConfig<T>
+) {
+  const [sortConfig, setSortConfig] = useState<SortConfig<T>>(
+    defaultSort || { key: '', direction: null }
+  );
+
+  const handleSort = (key: keyof T | string) => {
+    let direction: SortDirection = 'asc';
+    
+    if (sortConfig.key === key) {
+      if (sortConfig.direction === 'asc') {
+        direction = 'desc';
+      } else if (sortConfig.direction === 'desc') {
+        direction = null;
+      } else {
+        direction = 'asc';
+      }
+    }
+
+    setSortConfig({ key, direction });
+  };
+
+  const sortedData = useMemo(() => {
+    if (!sortConfig.key || !sortConfig.direction) {
+      return [...data];
+    }
+
+    return [...data].sort((a, b) => {
+      // Fonction pour obtenir une valeur imbriquée avec une chaîne comme "event.titre"
+      const getNestedValue = (obj: any, path: string) => {
+        return path.split('.').reduce((acc, part) => acc?.[part], obj);
+      };
+
+      const aValue = getNestedValue(a, sortConfig.key as string);
+      const bValue = getNestedValue(b, sortConfig.key as string);
+
+      if (aValue === null || aValue === undefined) return 1;
+      if (bValue === null || bValue === undefined) return -1;
+
+      if (aValue < bValue) {
+        return sortConfig.direction === 'asc' ? -1 : 1;
+      }
+      if (aValue > bValue) {
+        return sortConfig.direction === 'asc' ? 1 : -1;
+      }
+      return 0;
+    });
+  }, [data, sortConfig]);
+
+  return {
+    sortedData,
+    sortConfig,
+    handleSort,
+  };
+}

--- a/app/store/useStore.ts
+++ b/app/store/useStore.ts
@@ -32,7 +32,9 @@ const useStore = create<StoreState>((set) => ({
     dateFilter: '',
     requesterFilter: '',
     typeFilter: '',
-    setExpenseReports: (reports) => set({ expenseReports: reports }),
+    setExpenseReports: (reports) => set({ 
+        expenseReports: Array.isArray(reports) ? reports : [] 
+    }),
     setStatus: (status) => set({ status }),
     setItemsPerPage: (items) => set({ itemsPerPage: items }),
     setCurrentPage: (page) => set({ currentPage: page }),


### PR DESCRIPTION
## Résumé

Cette PR ajoute la fonctionnalité de tri sur toutes les colonnes du tableau des notes de frais, avec gestion améliorée des erreurs et de l'authentification.

## Nouvelles fonctionnalités

### 🔄 Tri des colonnes
- **Tri cliquable** sur toutes les colonnes du tableau
- **Indicateurs visuels** avec icônes de tri (flèches haut/bas)
- **Cycle de tri** : ascendant → descendant → pas de tri
- **Support des propriétés imbriquées** (ex: event.titre, user.lastname)

### 🛡️ Gestion améliorée de l'authentification
- **Refresh token automatique** en cas d'erreur 401 (JWT expiré)
- **Utilisation de fetchClient** pour toutes les requêtes API
- **Redirection automatique** vers la page de connexion si le refresh échoue

## Corrections de bugs

### 🐛 Erreur "reports.map is not a function"
- Vérification que les données sont bien un tableau avant traitement
- Initialisation avec un tableau vide en cas d'erreur
- Protection dans le store et les composants

## Détails techniques

### Nouveaux fichiers
- `app/hooks/useSortableTable.ts` - Hook réutilisable pour la logique de tri
- `app/components/note-de-frais/SortableHeader.tsx` - Composant d'en-tête triable

### Fichiers modifiés
- `ReportTable.tsx` - Intégration du tri et protection contre les erreurs
- `ExpenseReportsClient.tsx` - Utilisation de fetchClient pour le refresh token
- `useStore.ts` - Vérification du type de données

## Tests
- ✅ Tri ascendant/descendant sur toutes les colonnes
- ✅ Refresh token automatique en cas de JWT expiré
- ✅ Gestion des erreurs sans crash de l'application
- ✅ Indicateurs visuels du tri actif

## Captures d'écran
Les colonnes du tableau affichent maintenant des flèches indiquant :
- ⬆️ Tri ascendant (bleu)
- ⬇️ Tri descendant (bleu)
- ↕️ Pas de tri (gris clair)