### PR TITLE
fix(api): disable API Platform pagination and normalize list response

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `app/`: Next.js App Router (layouts, routes, `(public)`/`(private)` groups, `app/api/*`).
+- `components/`: Reusable UI components (e.g., `components/ui/*`).
+- `lib/`: Utilities and helpers (see `app/lib/*`, `lib/utils.ts`).
+- `public/`: Static assets served at `/`.
+- `tests/`: Playwright E2E specs and helpers.
+- Config: `playwright.config.ts`, `tailwind.config.js`, `next.config.js`, `instrumentation.ts`, `sentry.*.config.ts`.
+- Env: `.env.exemple` (template), `.env.local` (private, git‑ignored).
+
+## Build, Test, and Development Commands
+- `pnpm install`: Install dependencies.
+- `pnpm dev`: Start the app at `http://localhost:3000`.
+- `pnpm build`: Production build via Next.js.
+- `pnpm start`: Serve the production build.
+- `pnpm lint`: Lint with Next.js ESLint config.
+- `pnpm test:e2e`: Run Playwright tests headless.
+- `pnpm test:e2e:ui`: Open Playwright Test Runner UI.
+- `pnpm test:e2e:report`: View the HTML report.
+  Note: Playwright starts the dev server using `npm run dev` (see `playwright.config.ts`). Keep the `npm` alias available or update the config if standardizing on `pnpm`.
+
+## Coding Style & Naming Conventions
+- TypeScript + React (Next.js 15). Use functional components.
+- Indentation: 2 spaces; files: kebab-case (e.g., `global-error.tsx`).
+- Components: PascalCase; variables/functions: camelCase; env vars: SCREAMING_SNAKE_CASE.
+- Follow ESLint rules (`pnpm lint`). Prefer small, typed modules under `app/*`, `components/*`, `lib/*`.
+- TailwindCSS for styling; keep class lists readable and co-located with components.
+
+## Testing Guidelines
+- Framework: Playwright. Specs in `tests/*.spec.ts`.
+- Base URL: `http://localhost:3000` (configured). Start app with `pnpm dev` before running tests locally.
+- Prefer stable selectors (e.g., `data-testid`) for UI.
+- Add tests for new user flows and bug fixes. Keep specs fast and independent.
+
+## Commit & Pull Request Guidelines
+- Use Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, etc. Keep scope concise (e.g., `feat(ndf): ...`).
+- One logical change per commit; write imperative, present-tense messages.
+- PRs include: clear description, linked issue, screenshots for UI changes, and updates to `API.md`/`README.md` when relevant.
+- Ensure `pnpm lint` and E2E tests pass before requesting review.
+
+## Security & Configuration Tips
+- Copy `.env.exemple` to `.env.local`; never commit secrets.
+- Sentry is configured (`@sentry/nextjs`). Redact PII in logs and errors.
+- Validate external inputs; avoid exposing private APIs in client code. Prefer server components or API routes under `app/api/*` for sensitive logic.
+
+## Architecture Overview
+- App Router with route groups and API routes in `app/api`.
+- State management via `zustand` where needed.
+- Utilities (`lib/*`) and typed interfaces under `app/interfaces` for consistency.

--- a/API.md
+++ b/API.md
@@ -123,6 +123,33 @@ curl -X GET https://www.clubalpinlyon.top/api/notes-de-frais \
 }
 ```
 
+#### Liste non paginée
+
+Ajoutez le paramètre `pagination=false` pour désactiver la pagination (format de réponse = tableau brut) :
+
+```bash
+curl -X GET "https://www.clubalpinlyon.top/api/notes-de-frais?pagination=false" \
+  -H "Authorization: Bearer votre_token_jwt"
+```
+
+Réponse (200):
+
+```json
+[
+  {
+    "id": 1,
+    "status": "approved",
+    "refundRequired": false,
+    "utilisateur": { "id": 1, "prenom": "Admin", "nom": "SUPER" },
+    "sortie": { "id": 11, "status": 1, "statusLegal": 1, "titre": "..." },
+    "dateCreation": "2025-08-20T15:07:03+02:00",
+    "commentaireStatut": null,
+    "details": "{...}",
+    "piecesJointes": []
+  }
+]
+```
+
 ### Mise à jour du statut d'une note de frais
 
 Permet de mettre à jour le statut d'une note de frais spécifique (ex : approuver, rejeter, comptabiliser, etc.).

--- a/app/api/expense-reports/[slug]/route.ts
+++ b/app/api/expense-reports/[slug]/route.ts
@@ -9,8 +9,11 @@ export async function GET(
     // Attendre les paramètres avant de les utiliser
     const { slug } = await context.params;
     
-    // Récupérer les notes de frais depuis l'API Symfony
-    const apiResponse = await get(`${process.env.NEXT_PUBLIC_API_URL}/notes-de-frais?event=${slug}`);
+    // Récupérer les notes de frais depuis l'API Symfony, sans pagination
+    const apiResponse = await get(
+      `${process.env.NEXT_PUBLIC_API_URL}/notes-de-frais`,
+      { params: { event: slug, pagination: 'false' } }
+    );
     const expenseReport = apiResponse.data || apiResponse;
     return NextResponse.json(expenseReport);
   } catch (error) {


### PR DESCRIPTION
Changes\n- Disable pagination via API Platform flag: pagination=false (lists and event-scoped)\n- Normalize internal API to always return arrays (supports { data: [] } and [] formats)\n- Update API.md: document non-paginated format with example\n\nWhy\n- Frontend expects arrays; API now returns raw arrays when pagination is disabled. This removes format ambiguity and avoids client-side mapping.\n\nTesting\n- Run pnpm dev and pnpm test:e2e to validate flows\n- Manually verified app/api/expense-reports and app/api/expense-reports/[slug] behavior\n\nNotes\n- If fully standardizing on pnpm, consider switching Playwright webServer.command to pnpm dev.