### PR TITLE
fix: utilise le vrai itemsPerPage et rétablit le sélecteur par page

### DIFF
--- a/app/components/note-de-frais/Filters.tsx
+++ b/app/components/note-de-frais/Filters.tsx
@@ -15,12 +15,22 @@ const Filters: React.FC = () => {
         setRequesterFilter,
         typeFilter,
         setTypeFilter,
+        itemsPerPage,
+        setItemsPerPage,
         resetFilters
     } = useStore();
 
     return (
         <div className="flex flex-wrap items-center gap-2 my-2">
-            {/* TODO: Rétablir le sélecteur "par page" une fois les ApiFilter déployés sur le backend. */}
+            <select
+                value={itemsPerPage}
+                onChange={(e) => setItemsPerPage(Number(e.target.value))}
+                className="block w-20 py-2 px-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+            >
+                {[10, 25, 50].map((n) => (
+                    <option key={n} value={n}>{n}</option>
+                ))}
+            </select>
             <div className="relative">
                 <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
                     <FaFilter className="text-gray-400" />

--- a/app/components/note-de-frais/Filters.tsx
+++ b/app/components/note-de-frais/Filters.tsx
@@ -67,7 +67,7 @@ const Filters: React.FC = () => {
                     type="text"
                     value={requesterFilter}
                     onChange={(e) => setRequesterFilter(e.target.value)}
-                    placeholder="Nom du demandeur"
+                    placeholder="Nom de famille"
                     className="block w-full pl-10 pr-4 py-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
                 />
             </div>
@@ -92,7 +92,7 @@ const Filters: React.FC = () => {
                 <input
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    placeholder="Rechercher une note de frais"
+                    placeholder="Titre de la sortie"
                     className="block w-full pl-10 pr-4 py-2 text-sm text-gray-700 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
                 />
             </div>

--- a/app/components/note-de-frais/Pagination.tsx
+++ b/app/components/note-de-frais/Pagination.tsx
@@ -5,9 +5,9 @@ const Pagination: React.FC = () => {
     const currentPage = useStore((state) => state.currentPage);
     const setCurrentPage = useStore((state) => state.setCurrentPage);
     const paginationMeta = useStore((state) => state.paginationMeta);
-    const displayedCount = useStore((state) => state.displayedCount);
 
     const totalPages = paginationMeta?.pages ?? 1;
+    const totalCount = paginationMeta?.total ?? 0;
 
     const handlePrev = () => {
         if (currentPage > 1) setCurrentPage(currentPage - 1);
@@ -22,7 +22,7 @@ const Pagination: React.FC = () => {
     return (
         <div className="flex flex-col items-center px-5 py-5 bg-white border-t xs:flex-row xs:justify-between ">
       <span className="text-xs text-gray-900 xs:text-sm">
-        {displayedCount} note{displayedCount > 1 ? 's' : ''} de frais affichée{displayedCount > 1 ? 's' : ''}
+        {totalCount} note{totalCount > 1 ? 's' : ''} de frais
       </span>
             <div className="inline-flex mt-2 xs:mt-0">
                 <button

--- a/app/components/note-de-frais/ReportTable.tsx
+++ b/app/components/note-de-frais/ReportTable.tsx
@@ -1,7 +1,6 @@
 import { ExpenseReport } from "@/app/interfaces/noteDeFraisInterface";
 import ReportRow from './ReportRow';
-import React, { useEffect, useMemo } from "react";
-import useStore from "@/app/store/useStore";
+import React, { useMemo } from "react";
 import { useSortableTable } from '@/app/hooks/useSortableTable';
 import SortableHeader from './SortableHeader';
 import { calculateTotals } from '@/app/utils/helper';
@@ -12,13 +11,6 @@ interface ReportTableProps {
 }
 
 const ReportTable: React.FC<ReportTableProps> = ({ reports, isLoading }) => {
-    const status = useStore((state) => state.status);
-    const searchTerm = useStore((state) => state.searchTerm);
-    const dateFilter = useStore((state) => state.dateFilter);
-    const requesterFilter = useStore((state) => state.requesterFilter);
-    const typeFilter = useStore((state) => state.typeFilter);
-    const setDisplayedCount = useStore((state) => state.setDisplayedCount);
-
     // Ajouter le montant calculé à chaque rapport pour le tri
     const reportsWithAmount = useMemo(() => {
         if (!Array.isArray(reports)) return [];
@@ -28,32 +20,8 @@ const ReportTable: React.FC<ReportTableProps> = ({ reports, isLoading }) => {
         }));
     }, [reports]);
 
-    // TODO: Supprimer ce filtrage client-side une fois les ApiFilter déployés sur le backend.
-    // En attendant, on filtre dans la page courante pour que les filtres restent fonctionnels.
-    const reportFiltered = useMemo(() => {
-        const search = searchTerm.toLowerCase();
-        const requester = requesterFilter.toLowerCase();
-        return reportsWithAmount.filter((report) => {
-            const matchesStatus = status === 'Toutes' || report.status === status;
-            const matchesSearchTerm = report.sortie.titre.toLowerCase().includes(search);
-            const matchesDate = !dateFilter || new Date(report.sortie.heureRendezVous).toLocaleDateString() === new Date(dateFilter).toLocaleDateString();
-            const matchesRequester = !requester ||
-                (report.utilisateur.prenom.toLowerCase() + " " + report.utilisateur.nom.toLowerCase()).includes(requester);
-            const matchesType = !typeFilter ||
-                (typeFilter === 'don' && !report.refundRequired) ||
-                (typeFilter === 'remboursement' && report.refundRequired);
-
-            return matchesStatus && matchesSearchTerm && matchesDate && matchesRequester && matchesType;
-        });
-    }, [reportsWithAmount, status, searchTerm, dateFilter, requesterFilter, typeFilter]);
-
-    // TODO: Supprimer ce useEffect une fois les ApiFilter déployés sur le backend.
-    useEffect(() => {
-        setDisplayedCount(reportFiltered.length);
-    }, [reportFiltered.length, setDisplayedCount]);
-
     // Utiliser le hook de tri
-    const { sortedData, sortConfig, handleSort } = useSortableTable(reportFiltered);
+    const { sortedData, sortConfig, handleSort } = useSortableTable(reportsWithAmount);
 
     // Vérifier que reports est bien un tableau
     if (!Array.isArray(reports)) {
@@ -146,7 +114,7 @@ const ReportTable: React.FC<ReportTableProps> = ({ reports, isLoading }) => {
                                 Chargement des notes de frais...
                             </td>
                         </tr>
-                    ) : !reportFiltered.length ? (
+                    ) : !reportsWithAmount.length ? (
                         <tr>
                             <td colSpan={8} className="px-2 py-3 text-sm text-center text-gray-600 border-b">
                                 Aucune note de frais ne correspond aux critères de recherche.

--- a/app/hooks/useExpenseReports.ts
+++ b/app/hooks/useExpenseReports.ts
@@ -42,10 +42,7 @@ export function useExpenseReports() {
         try {
             const params = new URLSearchParams();
             params.set('page', String(currentPage));
-            // TODO: Envoyer itemsPerPage une fois les ApiFilter déployés sur le backend.
-            // En attendant, on demande le max (30) pour que le filtrage client-side ait
-            // assez de données pour afficher tous les résultats matchants sur une page.
-            params.set('itemsPerPage', '30');
+            params.set('itemsPerPage', String(itemsPerPage));
 
             if (status !== 'Toutes') {
                 params.set('status', status);

--- a/app/store/useStore.ts
+++ b/app/store/useStore.ts
@@ -5,7 +5,6 @@ import { ExpenseReport, PaginationMeta } from "../interfaces/noteDeFraisInterfac
 interface StoreState {
     expenseReports: ExpenseReport[];
     paginationMeta: PaginationMeta | null;
-    displayedCount: number;
     isLoading: boolean;
     status: string;
     itemsPerPage: number;
@@ -16,7 +15,6 @@ interface StoreState {
     typeFilter: string;
     setExpenseReports: (reports: ExpenseReport[]) => void;
     setPaginationMeta: (meta: PaginationMeta | null) => void;
-    setDisplayedCount: (count: number) => void;
     setIsLoading: (loading: boolean) => void;
     setStatus: (status: string) => void;
     setItemsPerPage: (items: number) => void;
@@ -31,7 +29,6 @@ interface StoreState {
 const useStore = create<StoreState>((set) => ({
     expenseReports: [],
     paginationMeta: null,
-    displayedCount: 0,
     isLoading: false,
     status: 'submitted',
     itemsPerPage: 10,
@@ -44,7 +41,6 @@ const useStore = create<StoreState>((set) => ({
         expenseReports: Array.isArray(reports) ? reports : []
     }),
     setPaginationMeta: (meta) => set({ paginationMeta: meta }),
-    setDisplayedCount: (count) => set({ displayedCount: count }),
     setIsLoading: (loading) => set({ isLoading: loading }),
     setStatus: (status) => set({ status, currentPage: 1 }),
     setItemsPerPage: (items) => set({ itemsPerPage: items, currentPage: 1 }),

--- a/tests/unit/hooks/useExpenseReports.test.ts
+++ b/tests/unit/hooks/useExpenseReports.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import useStore from '@/app/store/useStore';
+import { mockExpenseReports } from '@/tests/mocks/fixtures';
+
+// Mock fetchClient to intercept API calls without hitting the network
+vi.mock('@/app/lib/fetchClient', () => ({
+  get: vi.fn(),
+}));
+
+import { get } from '@/app/lib/fetchClient';
+import { useExpenseReports } from '@/app/hooks/useExpenseReports';
+
+const mockedGet = vi.mocked(get);
+
+const paginatedResponse = {
+  data: mockExpenseReports.slice(0, 2),
+  meta: { page: 1, perPage: 10, total: 2, pages: 1 },
+};
+
+describe('useExpenseReports', () => {
+  beforeEach(() => {
+    mockedGet.mockClear();
+    mockedGet.mockResolvedValue(paginatedResponse);
+    act(() => {
+      useStore.setState({
+        expenseReports: [],
+        paginationMeta: null,
+        isLoading: false,
+        status: 'submitted',
+        itemsPerPage: 10,
+        currentPage: 1,
+        searchTerm: '',
+        dateFilter: '',
+        requesterFilter: '',
+        typeFilter: '',
+      });
+    });
+  });
+
+  function lastCalledUrl(): string {
+    const calls = mockedGet.mock.calls;
+    return calls[calls.length - 1][0] as string;
+  }
+
+  function lastCalledParams(): URLSearchParams {
+    return new URLSearchParams(lastCalledUrl().split('?')[1]);
+  }
+
+  it('sends itemsPerPage from store', async () => {
+    act(() => useStore.getState().setItemsPerPage(25));
+    renderHook(() => useExpenseReports());
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalled());
+    expect(lastCalledParams().get('itemsPerPage')).toBe('25');
+  });
+
+  it('sends default itemsPerPage of 10', async () => {
+    renderHook(() => useExpenseReports());
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalled());
+    expect(lastCalledParams().get('itemsPerPage')).toBe('10');
+  });
+
+  it('sends status filter', async () => {
+    act(() => useStore.getState().setStatus('approved'));
+    renderHook(() => useExpenseReports());
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalled());
+    expect(lastCalledParams().get('status')).toBe('approved');
+  });
+
+  it('omits status param when "Toutes"', async () => {
+    act(() => useStore.getState().setStatus('Toutes'));
+    renderHook(() => useExpenseReports());
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalled());
+    expect(lastCalledParams().has('status')).toBe(false);
+  });
+
+  it('sends refundRequired=false for don filter', async () => {
+    act(() => useStore.getState().setTypeFilter('don'));
+    renderHook(() => useExpenseReports());
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalled());
+    expect(lastCalledParams().get('refundRequired')).toBe('false');
+  });
+
+  it('sends refundRequired=true for remboursement filter', async () => {
+    act(() => useStore.getState().setTypeFilter('remboursement'));
+    renderHook(() => useExpenseReports());
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalled());
+    expect(lastCalledParams().get('refundRequired')).toBe('true');
+  });
+
+  it('sends date range params for dateFilter', async () => {
+    act(() => useStore.getState().setDateFilter('2025-06-15'));
+    renderHook(() => useExpenseReports());
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalled());
+    const params = lastCalledParams();
+    expect(params.get('event.startDate[after]')).toBe('2025-06-15T00:00:00');
+    expect(params.get('event.startDate[before]')).toBe('2025-06-15T23:59:59');
+  });
+
+  it('stores fetched reports and pagination meta', async () => {
+    renderHook(() => useExpenseReports());
+
+    await waitFor(() => {
+      expect(useStore.getState().expenseReports).toEqual(paginatedResponse.data);
+      expect(useStore.getState().paginationMeta).toEqual(paginatedResponse.meta);
+    });
+  });
+
+  it('sets error on fetch failure', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('Network error'));
+    const { result } = renderHook(() => useExpenseReports());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Network error');
+    });
+  });
+});

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -8,6 +8,7 @@ describe('useStore', () => {
     act(() => {
       useStore.setState({
         expenseReports: [],
+        paginationMeta: null,
         status: 'submitted',
         itemsPerPage: 10,
         currentPage: 1,


### PR DESCRIPTION
## Summary
- **`itemsPerPage` n'est plus hardcodé à 30** : maintenant que les filtres API Platform sont déployés côté backend (PR #1691 sur plateforme-club-alpin), on envoie la vraie valeur du store (défaut : 10)
- **Sélecteur "par page" rétabli** dans la barre de filtres (10 / 25 / 50)
- **Tests unitaires** ajoutés pour le hook `useExpenseReports` (9 tests couvrant tous les query params envoyés à l'API)

## Test plan
- [ ] Vérifier que le sélecteur "par page" apparaît et change le nombre de résultats
- [ ] Vérifier que la pagination fonctionne correctement avec 10/25/50 items
- [ ] Vérifier que les filtres (statut, date, type don/remboursement) fonctionnent
- [ ] Vérifier `pnpm test:unit` passe (112 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d'un sélecteur de pagination permettant de choisir 10, 25 ou 50 éléments par page.

* **Améliorations**
  * Mise à jour des libellés des champs : "Nom de famille" pour le filtre demandeur et "Titre de la sortie" pour la recherche.

* **Tests**
  * Ajout de tests unitaires couvrant la récupération des rapports de dépenses, les filtres, la pagination et la gestion des erreurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->